### PR TITLE
Update Figma Linux to 0.11.4

### DIFF
--- a/io.github.Figma_Linux.figma_linux.appdata.xml
+++ b/io.github.Figma_Linux.figma_linux.appdata.xml
@@ -6,14 +6,12 @@
   <developer_name>Chugunov Roman</developer_name>
   <icon type="remote">
     https://raw.githubusercontent.com/Figma-Linux/figma-linux/dev/resources/icons/512x512.png</icon>
+  <launchable type="desktop-id">io.github.Figma_Linux.figma_linux.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
-  <description>
-     Figma is the first interface design tool based in the browser, making it easier for
-    teams to create software. 
-  
-    <p>NOTE: This wrapper is not verified by, affiliated with, or
-    supported by Figma, Inc.</p>
+  <description> Figma is the first interface design tool based in the browser, making it easier for
+    teams to create software. <p>NOTE: This wrapper is not verified by, affiliated with, or
+      supported by Figma, Inc.</p>
   </description>
   <url type="homepage">https://github.com/Figma-Linux/figma-linux</url>
   <url type="bugtracker">https://github.com/Figma-Linux/figma-linux/issues</url>
@@ -37,32 +35,30 @@
     <content_attribute id="money-purchasing">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="0.11.4" date="2024-05-26">
+      <description>
+        <ul>
+          <li>Bug Fixes:</li>
+          <li>Set appVersion to ignore version checking
+          </li>
+          <li>Other Changes:</li>
+          <li>Update the release ci</li>
+          <li>Bump Electron from 27.2.2 to 30.0.8</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.11.3" date="2024-01-15">
       <description>
         <ul>
           <li>Bug Fixes:</li>
-          <li>
-            import a plugin from manifest.json. 
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/358" target="_blank">#358</a>
-          </li>
-          <li>
-            visible font selection field. 
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/356" target="_blank">#356</a>
-          </li>
-          <li>
-            use default settings if can not parse settings.json file. 
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/357" target="_blank">#357</a>
-          </li>
-          <li>
-            validate file path for extension file. 
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/352" target="_blank">#352</a>
-          </li>
-          <li/>
+          <li> import a plugin from manifest.json.</li>
+          <li> visible font selection field.</li>
+          <li> use default settings if can not parse settings.json file.</li>
+          <li> validate file path for extension file.</li>
           <li>Other Changes:</li>
           <li>Bump Electron from 27.2.0 to 27.2.2</li>
           <li>Bump Electron from 27.0.4 to 27.2.0</li>
           <li>set default values for dev ports</li>
-          <li/>
         </ul>
       </description>
     </release>
@@ -71,10 +67,8 @@
         <ul>
           <li>Bug Fixes:</li>
           <li>update files for build on launchpad</li>
-          <li/>
           <li>Other Changes:</li>
           <li>update build ppa script</li>
-          <li/>
         </ul>
       </description>
     </release>
@@ -82,12 +76,7 @@
       <description>
         <ul>
           <li>Bug Fixes:</li>
-          <li>
-             copy as png. 
-          
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/350" target="_blank">#350</a>
-          </li>
-          <li/>
+          <li> copy as png.</li>
           <li>Other Changes:</li>
           <li>update deb files</li>
           <li>add desktop file for dev build</li>
@@ -95,7 +84,6 @@
           <li>update snapcraft config</li>
           <li>update generate release notes</li>
           <li>update ci</li>
-          <li/>
         </ul>
       </description>
     </release>
@@ -116,7 +104,6 @@
           <li>implement multiple windows</li>
           <li>Rework frontend. Delete React, Mobx, Webpack, node-sass and etc. And add RollUp and
             Svelte</li>
-          <li/>
           <li>Bug Fixes:</li>
           <li>main pipeline</li>
           <li>display themes list after first sync</li>
@@ -163,16 +150,8 @@
           <li>move font manager on nodeJS side</li>
           <li>init settings if file exists with partial data</li>
           <li>error when try restore empty tab list</li>
-          <li>
-             mic access. 
-          
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/317" target="_blank">#317</a>
-          </li>
-          <li>
-             export files. 
-          
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/203" target="_blank">#203</a>
-          </li>
+          <li> mic access.</li>
+          <li> export files.</li>
           <li>remove a tab object from the svelte store after the close tab from context menu</li>
           <li>copy a project url, and reload a tab</li>
           <li>save and restore tabs after open a window</li>
@@ -196,17 +175,9 @@
           <li>sync themes</li>
           <li>change zoom for the ZoomView component</li>
           <li>toggling the main menu</li>
-          <li>
-             Fix build-id conflicts with other packages ( 
-          
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/310)" target="_blank">#310)</a>
+          <li>Fix build-id conflicts with other packages.
           </li>
-          <li>
-             Local plugins are reset on application exit. 
-          
-            <a href="https://github.com/Figma-Linux/figma-linux/issues/296" target="_blank">#296</a>
-          </li>
-          <li/>
+          <li>Local plugins are reset on application exit.</li>
           <li>Other Changes:</li>
           <li>update readme</li>
           <li>update snapcraft config</li>
@@ -323,15 +294,14 @@
           <li>move the openTabMenu handler to the WindowsManager</li>
           <li>cleaned up the code a bit</li>
           <li>move the setFocusToMainTab handler to WindowsManager class</li>
-          <li/>
         </ul>
       </description>
     </release>
-    <release version="0.9.6" date="2022-03-19"/>
-    <release version="0.9.4" date="2022-02-20"/>
-    <release version="0.9.3" date="2021-12-09"/>
-    <release version="0.9.2" date="2021-10-16"/>
-    <release version="0.9.1" date="2021-10-14"/>
+    <release version="0.9.6" date="2022-03-19" />
+    <release version="0.9.4" date="2022-02-20" />
+    <release version="0.9.3" date="2021-12-09" />
+    <release version="0.9.2" date="2021-10-16" />
+    <release version="0.9.1" date="2021-10-14" />
     <release version="0.8.1" date="2021-04-05">
       <description>
         <ul>

--- a/io.github.Figma_Linux.figma_linux.desktop
+++ b/io.github.Figma_Linux.figma_linux.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=figma-linux
 Comment=Unofficial Figma application for Linux
-Exec=figma-linux --enable-oop-rasterization --ignore-gpu-blacklist -enable-experimental-canvas-features --enable-accelerated-2d-canvas --force-gpu-rasterization --enable-fast-unload --enable-accelerated-vpx-decode=3 --enable-tcp-fastopen --javascript-harmony --enable-checker-imaging --v8-cache-options=code --v8-cache-strategies-for-cache-storage=aggressive --enable-zero-copy --ui-enable-zero-copy --enable-native-gpu-memory-buffers --enable-webgl-image-chromium --enable-accelerated-video --enable-gpu-rasterization %U
+Exec=figma-linux --enable-oop-rasterization --ignore-gpu-blacklist -enable-experimental-canvas-features --enable-accelerated-2d-canvas --force-gpu-rasterization --enable-fast-unload --enable-accelerated-vpx-decode=3 --enable-tcp-fastopen --javascript-harmony --enable-checker-imaging --v8-cache-options=code --v8-cache-strategies-for-cache-storage=aggressive --enable-zero-copy --ui-enable-zero-copy --enable-native-gpu-memory-buffers --enable-accelerated-video --enable-gpu-rasterization %U
 Terminal=false
 Type=Application
 Icon=io.github.Figma_Linux.figma_linux

--- a/io.github.Figma_Linux.figma_linux.yml
+++ b/io.github.Figma_Linux.figma_linux.yml
@@ -1,15 +1,15 @@
 id: io.github.Figma_Linux.figma_linux
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: "23.08"
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: "23.08"
 finish-args:
-  - '--share=ipc'
-  - '--socket=x11'
-  - '--device=dri'
-  - '--share=network'
-  - '--filesystem=xdg-pictures'
+  - --share=ipc
+  - --socket=x11
+  - --device=dri
+  - --share=network
+  - --filesystem=xdg-pictures
 command: figma-linux
 rename-icon: figma-linux
 modules:
@@ -32,8 +32,8 @@ modules:
         only-arches:
           - x86_64
         url: >-
-          https://github.com/Figma-Linux/figma-linux/releases/download/v0.11.3/figma-linux_0.11.3_linux_amd64.deb
-        sha256: f547f20aa82c83d5c017267b57b4e8824428bb8c7e8b11547e35d9d7faa50e60
+          https://github.com/Figma-Linux/figma-linux/releases/download/v0.11.4/figma-linux_0.11.4_linux_amd64.deb
+        sha256: ba452c36058eb4845ee78bec991748eb6b328c83f04ac80d57b9084c2c346144
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Figma-Linux/figma-linux/releases/latest
@@ -45,8 +45,8 @@ modules:
         only-arches:
           - aarch64
         url: >-
-          https://github.com/Figma-Linux/figma-linux/releases/download/v0.11.3/figma-linux_0.11.3_linux_arm64.deb
-        sha256: 58d05ead9ba0936d3fc2e044df913dc62d7538ada9b72c1921007a5557c7f45f
+          https://github.com/Figma-Linux/figma-linux/releases/download/v0.11.4/figma-linux_0.11.4_linux_arm64.deb
+        sha256: bd3b22404541bf819320be9635f54fcd4cce1915bc21c339c9a34966f74959bb
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Figma-Linux/figma-linux/releases/latest


### PR DESCRIPTION
This PR contains changes from #51, #52, #53 and #55 and supersedes them. It also fixes [this sandbox error](https://github.com/flathub/io.github.Figma_Linux.figma_linux/pull/55#issuecomment-2149339287).

Basically we have working Flatpak Figma now (I hope CI won't fail).